### PR TITLE
Enable order with None in mockgun

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -293,6 +293,27 @@ class Shotgun(object):
         # handle the ordering of the recordset
         if order:
             # order: [{"field_name": "code", "direction": "asc"}, ... ]
+
+            def sort_none(k, order_field):
+                """
+                Handle sorting of None consistently.
+
+                Note: Doesn't handle [checkbox, serializable, url].
+                """
+                field_type = self._get_field_type(k["type"], order_field)
+                value = k[order_field]
+                if value is not None:
+                    return value
+                elif field_type in ("number", "percent", "duration"):
+                    return 0
+                elif field_type == "float":
+                    return 0.0
+                elif field_type in ("text", "entity_type", "date", "list", "status_list"):
+                    return ""
+                elif field_type == "date_time":
+                    return datetime.datetime(datetime.MINYEAR, 1, 1)
+                return None
+
             for order_entry in order:
                 if "field_name" not in order_entry:
                     raise ValueError("Order clauses must be list of dicts with keys 'field_name' and 'direction'!")
@@ -305,7 +326,11 @@ class Shotgun(object):
                 else:
                     raise ValueError("Unknown ordering direction")
 
-                results = sorted(results, key=lambda k: k[order_field], reverse=desc_order)
+                results = sorted(
+                    results,
+                    key=lambda k: sort_none(k, order_field),
+                    reverse=desc_order,
+                )
 
         if fields is None:
             fields = set(["type", "id"])


### PR DESCRIPTION
Prevents an TypeError when checking if `None > str`

Prevents errors like this when using order on `sg.find`.
```py
TypeError: '>' not supported between instances of 'NoneType' and 'str'
```

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [ ] I formatted my changes with [black](https://github.com/psf/black)
- [ ] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [ ] I have added documentation regarding my changes where necessary
- [ ] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
